### PR TITLE
Add note to readme explaining alternative installation method

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,9 @@ This is the default template for use within [spike](https://github.com/static-de
 - `spike tpl add jekyll git@github.com:static-dev/spike-tpl-jekyll.git`
 - `spike new <projectname> -t jekyll`
 
-> NOTE: Because this template uses [Spike Collections](https://github.com/static-dev/spike-collections#installation), you cannot use the globally installed spike CLI with this template. Instead, you must install spike locally (npm i spike -S), then execute that version. Typically adding an npm script that runs spike watch is the best approach.
+> NOTE: Because this template uses [Spike Collections](https://github.com/static-dev/spike-collections#installation), you cannot use the globally installed spike CLI with this template. Instead, you must use the locally installed spike via npm.
+
+- `npm start`
 
 
 ### Standalone

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,9 @@ This is the default template for use within [spike](https://github.com/static-de
 - `spike tpl add jekyll git@github.com:static-dev/spike-tpl-jekyll.git`
 - `spike new <projectname> -t jekyll`
 
+> NOTE: Because this template uses [Spike Collections](https://github.com/static-dev/spike-collections#installation), you cannot use the globally installed spike CLI with this template. Instead, you must install spike locally (npm i spike -S), then execute that version. Typically adding an npm script that runs spike watch is the best approach.
+
+
 ### Standalone
 
 [Spike](https://github.com/static-dev/spike) uses [sprout](https://github.com/carrot/sprout) internally to generate it's project templates. This means you can even use this template without [spike](https://github.com/static-dev/spike) by using [sprout](https://github.com/carrot/sprout) directly.


### PR DESCRIPTION
Because the template uses Spike Collections it's subject to the same
installation workaround as the plugin, so documenting that here for new
users.